### PR TITLE
Add `lsp_yaml` via `yaml-language-server`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The following languages are supported, bundled with their particular language se
 | [lsp_rust](/plugins/lsp_rust.lua?raw=1)                      | Rust                           | [rust-analyzer](https://github.com/rust-lang/rust-analyzer)                                            | Linux, Mac, Windows
 | [lsp_tex](/plugins/lsp_tex.lua?raw=1)                        | TeX                            | [texlab](https://github.com/latex-lsp/texlab)                                                          | Linux, Mac, Windows
 | [lsp_typescript](/plugins/lsp_typescript.lua?raw=1)          | Javascript, Typescript         | [typescript-language-server](https://github.com/typescript-language-server/typescript-language-server) | Linux, Mac, Windows
+| [lsp_yaml](/plugins/lsp_yaml.lua?raw=1)                      | YAML                           | [yaml-language-server](https://github.com/redhat-developer/yaml-language-server)                       | Linux, Mac, Windows
 | [lsp_zig](/plugins/lsp_zig.lua?raw=1)                        | Zig                            | [zls](https://github.com/zigtools/zls)                                                                 | Linux, Mac, Windows
 
 ## Additional libraries

--- a/manifest.json
+++ b/manifest.json
@@ -269,6 +269,21 @@
     ],
     "dependencies": { "language_ts": {}, "language_js": {}, "lsp": {}, "nodejs": {} }
   },{
+    "id": "lsp_yaml",
+    "description": "LSP support for YAML via yaml-language-server.",
+    "path": "plugins/lsp_yaml.lua",
+    "version": "1.14.0",
+    "files": [
+      {
+        "url": "https://github.com/lite-xl/lite-xl-lsp-servers/releases/download/yaml-language-server-1.14.0/yaml-language-server-1.14.0.tar.gz",
+        "checksum": "830531fce7f62f3b49d44844b7867f5e03d51e2e24ddf5fc2704d503b485b589"
+      }
+    ],
+    "dependencies": {
+      "language_yaml": {},
+      "lsp": {}, "nodejs": {}
+    }
+  },{
     "id": "lsp_zig",
     "description": "LSP support for Zig via zls.",
     "path": "plugins/lsp_zig.lua",

--- a/plugins/lsp_yaml.lua
+++ b/plugins/lsp_yaml.lua
@@ -1,0 +1,12 @@
+-- mod-version:3
+
+local lspconfig = require "plugins.lsp.config"
+local common = require "core.common"
+local config = require "core.config"
+
+local installed_path = USERDIR .. PATHSEP .. "plugins" .. PATHSEP .. "lsp_yaml" .. PATHSEP .. "yaml-language-server" .. PATHSEP .. "dist" .. PATHSEP .. "index.js"
+local node = require "libraries.nodejs"
+
+lspconfig.yamlls.setup(common.merge({
+  command = { node.path_bin, installed_path, "--stdio" },
+}, config.plugins.lsp_yaml or {}))


### PR DESCRIPTION
~~This uses `yaml-language-server` for JSON too, even if it might not be appropriate for all cases.~~
~~I'll remove JSON from this when we get a proper JSON LSP.~~

~~The advantage of `yaml-language-server` over `vscode-json-languageserver` is that it automatically downloads schema definitions from https://www.schemastore.org, even if I had to trick it into thinking schemas for `.json` files are actually schemas for `yaml` files (it would have filtered them out otherwise).~~

~~I might consider forking `vscode-json-languageserver` and adding the feature there directly.~~

Edit: done in #27.