### PR TITLE
Add `vscode-json-languageserver` bundling

### DIFF
--- a/.github/workflows/vscode-json-languageserver.yaml
+++ b/.github/workflows/vscode-json-languageserver.yaml
@@ -1,0 +1,51 @@
+name: Package vscode-json-languageserver
+
+on:
+  workflow_dispatch:
+    inputs:
+      vscode-json-languageserver_version:
+        type: string
+        required: true
+      patches_version:
+        type: string
+        required: true
+
+jobs:
+  package_all:
+    name: Package JSON Language Server
+    runs-on: ubuntu-latest
+    permissions: write-all
+    env:
+      VERSION: ${{ inputs.vscode-json-languageserver_version }}
+      PATCHES_VERSION: ${{ inputs.patches_version }}
+      PATCHED_VERSION: ${{ inputs.vscode-json-languageserver_version }}-patch-${{ inputs.patches_version }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Update Packages
+        run: sudo apt-get update -y
+      - name: Install Dependencies
+        run: sudo apt-get install -y npm nodejs
+      - name: Get vscode
+        run: |
+          curl -L -o "v${VERSION}.tar.gz" "https://github.com/microsoft/vscode/archive/refs/tags/${VERSION}.tar.gz"
+      - name: Build vscode-json-languageserver
+        run: |
+          tar -xzvf "v${VERSION}.tar.gz"
+          git apply --directory=vscode-${VERSION} patches/vscode-json-languageserver/*.patch --verbose
+          cd "vscode-${VERSION}/extensions/json-language-features/server"
+          npm i @vercel/ncc typescript
+          # replace /umd/ with /esm/ in some require paths,
+          # as /umd/ files don't seem to get picked up by ncc
+          sed -i 's/\/umd\//\/esm\//g' node_modules/vscode-json-languageservice/package.json
+          npx ncc build src/node/jsonServerNodeMain.ts --license LICENSES
+      - name: Package
+        run: |
+          mkdir bundle
+          cp -r vscode-${VERSION}/LICENSE.txt vscode-${VERSION}/extensions/json-language-features/server/dist bundle
+          mv bundle vscode-json-languageserver
+          tar -zcvf vscode-json-languageserver-${PATCHED_VERSION}.tar.gz vscode-json-languageserver
+      - name: Create Release
+        env: { GITHUB_TOKEN: "${{ github.token }}" }
+        run: |
+          gh release delete -y "vscode-json-languageserver-${PATCHED_VERSION}" || true
+          gh release create -t "vscode-json-languageserver-${PATCHED_VERSION}" "vscode-json-languageserver-${PATCHED_VERSION}" "vscode-json-languageserver-${PATCHED_VERSION}.tar.gz"

--- a/patches/vscode-json-languageserver/0001-Add-simple-schemastore.org-integration.patch
+++ b/patches/vscode-json-languageserver/0001-Add-simple-schemastore.org-integration.patch
@@ -1,0 +1,86 @@
+From 8162419a8e3bbdec3007c6a4bc92385938fb51af Mon Sep 17 00:00:00 2001
+From: Guldoman <giulio.lettieri@gmail.com>
+Date: Wed, 20 Mar 2024 02:42:20 +0100
+Subject: [PATCH] Add simple schemastore.org integration
+
+---
+ .../server/src/jsonServer.ts                  | 35 +++++++++++++++++++
+ 1 file changed, 35 insertions(+)
+
+diff --git a/extensions/json-language-features/server/src/jsonServer.ts b/extensions/json-language-features/server/src/jsonServer.ts
+index 36ca0dc591d..eb60838b373 100644
+--- a/extensions/json-language-features/server/src/jsonServer.ts
++++ b/extensions/json-language-features/server/src/jsonServer.ts
+@@ -15,6 +15,7 @@ import { TextDocument, JSONDocument, JSONSchema, getLanguageService, DocumentLan
+ import { getLanguageModelCache } from './languageModelCache';
+ import { Utils, URI } from 'vscode-uri';
+ import * as l10n from '@vscode/l10n';
++import { xhr, XHRResponse } from 'request-light';
+ 
+ type ISchemaAssociations = Record<string, string[]>;
+ 
+@@ -135,6 +136,8 @@ export function startServer(connection: Connection, runtime: RuntimeEnvironment)
+ 	// in the passed params the rootPath of the workspace plus the client capabilities.
+ 	connection.onInitialize((params: InitializeParams): InitializeResult => {
+ 
++		setSchemaStoreSettingsIfNotSet();
++
+ 		const initializationOptions = params.initializationOptions as any || {};
+ 
+ 		const handledProtocols = initializationOptions?.handledSchemaProtocols;
+@@ -223,6 +226,7 @@ export function startServer(connection: Connection, runtime: RuntimeEnvironment)
+ 		schema?: JSONSchema;
+ 		folderUri?: string;
+ 	}
++	let schemaStoreSettings: SchemaConfiguration[] = [];
+ 
+ 
+ 
+@@ -266,6 +270,34 @@ export function startServer(connection: Connection, runtime: RuntimeEnvironment)
+ 		}
+ 	});
+ 
++	function setSchemaStoreSettingsIfNotSet(){
++		if(schemaStoreSettings.length === 0){
++			getSchemaStoreMatchingSchemas().then(schemaStore => {
++				schemaStoreSettings = schemaStore.schemas;
++				updateConfiguration();
++			});
++		}
++	}
++
++	function getSchemaStoreMatchingSchemas(){
++		return xhr({ url: "http://schemastore.org/api/json/catalog.json" }).then(response => {
++			let languageSettings = {
++				schemas: new Array<SchemaConfiguration>()
++			};
++
++			let schemas = JSON.parse(response.responseText);
++			for(let schemaIndex in schemas.schemas){
++				let schema = schemas.schemas[schemaIndex];
++				languageSettings.schemas.push({ uri: schema.url, fileMatch: schema.fileMatch || [] });
++			}
++
++			return languageSettings;
++		}, (error: XHRResponse) => {
++			throw error;
++		});
++
++	}
++
+ 	// The jsonValidation extension configuration has changed
+ 	connection.onNotification(SchemaAssociationNotification.type, associations => {
+ 		schemaAssociations = associations;
+@@ -350,6 +382,9 @@ export function startServer(connection: Connection, runtime: RuntimeEnvironment)
+ 				}
+ 			});
+ 		}
++		if(schemaStoreSettings){
++			languageSettings.schemas = languageSettings.schemas.concat(schemaStoreSettings);
++		}
+ 		languageService.configure(languageSettings);
+ 
+ 		diagnosticsSupport?.requestRefresh();
+-- 
+2.44.0
+

--- a/patches/vscode-json-languageserver/README.md
+++ b/patches/vscode-json-languageserver/README.md
@@ -1,0 +1,3 @@
+This directory contains patches to add the following functionality to `vscode-json-languageserver`:
+
+* Automatic download of JSON schemas from schemastore.org


### PR DESCRIPTION
Just like in #23, this needed a little bit of `sed` magic to be properly bundled by `ncc`.

This also patches `vscode-json-languageserver` (with code inspired by `yaml-language-server`) to add automatic schema matching with [schemastore.org](https://schemastore.org).
In the future I'll add options to allow changing/disabling the schema store.