### PR TITLE
Switch actions from `actions/checkout@v3` to `actions/checkout@v4`

### DIFF
--- a/.github/workflows/emmet-language-server.yml
+++ b/.github/workflows/emmet-language-server.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       VERSION: ${{ inputs.emmet-language-server_version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Update Packages
         run: sudo apt-get update -y
       - name: Install Dependencies

--- a/.github/workflows/typescript-language-server.yml
+++ b/.github/workflows/typescript-language-server.yml
@@ -20,7 +20,7 @@ jobs:
       VERSION: ${{ inputs.typescript-language-server_version }}
       TS_VERSION: ${{ inputs.tsserver_version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Update Packages
         run: sudo apt-get update -y
       - name: Install Dependencies

--- a/.github/workflows/vscode-json-languageserver.yaml
+++ b/.github/workflows/vscode-json-languageserver.yaml
@@ -20,7 +20,7 @@ jobs:
       PATCHES_VERSION: ${{ inputs.patches_version }}
       PATCHED_VERSION: ${{ inputs.vscode-json-languageserver_version }}-patch-${{ inputs.patches_version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Update Packages
         run: sudo apt-get update -y
       - name: Install Dependencies

--- a/.github/workflows/yaml-language-server.yml
+++ b/.github/workflows/yaml-language-server.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       VERSION: ${{ inputs.yaml-language-server_version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Update Packages
         run: sudo apt-get update -y
       - name: Install Dependencies


### PR DESCRIPTION
This silences the `Node.js 16 actions are deprecated.` warning.